### PR TITLE
Compatibility with WordPress 4.3

### DIFF
--- a/rapid-adn-widget.php
+++ b/rapid-adn-widget.php
@@ -3,22 +3,22 @@
 Plugin Name: Rapid App.net Widget
 Plugin URI: 
 Description: Display the latest updates from a App.net user inside a widget. 
-Version: 1.1
-Author: Peter Wilson, Floate Design Partners
+Version: 1.2
+Author: Peter Wilson
 Author URI: 
 License: GPLv2
 */
 
-define('RAPID_ADN_WIDGET_VERSION', '1.1');
+define('RAPID_ADN_WIDGET_VERSION', '1.2');
 
 class Rapid_ADN_Widget extends WP_Widget {
 
-	function Rapid_ADN_Widget() {
+	function __construct() {
 		$widget_ops = array(
 			'classname'   => 'widget_adn widget_adn--hidden',
 			'description' => __( 'Display your posts from App.net')
 		);
-		parent::WP_Widget( 'rapid-adn', __( 'Rapid App.net' ), $widget_ops );
+		parent::__construct( 'rapid-adn', __( 'Rapid App.net' ), $widget_ops );
 		
 		if ( is_active_widget(false, false, $this->id_base) ) {
 			add_action( 'wp_head', array(&$this, 'rapid_adn_widget_style') );

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Rapid App.Net Widget ===
 Contributors: peterwilsoncc
 Tags: adn, app.net, widget
-Stable tag: 1.1
+Stable tag: 1.2
 Requires at least: 3.4.2
-Tested up to: 3.5.1
+Tested up to: 4.3
 License: GPLv2
 
 Display posts from one or more App.net accounts using a WordPress widget.
@@ -70,6 +70,10 @@ nicely [summarised by Nicolas Gallagher](https://gist.github.com/1309546).
 They're a little strange at first but I find them surprisingly useful. 
 
 == Changelog ==
+
+= 1.2 =
+
+* Compatibility with WordPress 4.3
 
 = 1.1 =
 


### PR DESCRIPTION
- Rename the PHP 4 constructor
- refer to correct parent constructor
- Update version number
